### PR TITLE
[PR#3] Story: 사용자는 HTTPS로 경고 없이 다운로드할 수 있으며, HTTP는 HTTPS로 리다이렉트된다

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -46,7 +46,29 @@ curl -I https://dl.meowti.kr/instance.zip
 - `/srv/web/dl.meowti.kr/files/instance.sha256`이 최신 sha 파일을 가리킴
 - `cat instance.sha256`의 해시와 `sha256sum` 결과가 동일
 
-## 3) 트러블슈팅
+## 3) HTTPS/Redirect 검증 (Story #4)
+
+정책(역할 분리):
+- `http -> https` 리다이렉트 책임은 Cloudflare Edge가 가진다.
+- Origin nginx는 정적 파일 서빙만 담당하고, TLS 종단/리다이렉트 정책은 Cloudflare에서 운영한다.
+
+검증 커맨드:
+```bash
+curl -I http://dl.meowti.kr/instance.zip
+curl -I https://dl.meowti.kr/instance.zip
+```
+
+기대 결과:
+- HTTP 응답은 `301/302/308` + `Location: https://dl.meowti.kr/...`
+- HTTPS 응답은 `200 OK` (브라우저 인증서 경고 없음)
+- HSTS를 쓰기로 결정했다면 `strict-transport-security` 헤더가 존재
+
+실패 시 조치:
+- HTTP가 `200`이면 Cloudflare Redirect Rule 또는 Always Use HTTPS 설정을 재확인
+- 인증서 경고가 있으면 Cloudflare SSL/TLS 모드와 인증서 상태를 재확인
+- 원인 확인 후 결과를 본 문서에 날짜와 함께 갱신
+
+## 4) 트러블슈팅
 
 `ERR: input zip not found`:
 - 입력 경로 확인: `ls -l /srv/shared/downloads`
@@ -64,10 +86,10 @@ curl -I https://dl.meowti.kr/instance.zip
 - `docker logs --tail=200 infra-nginx`
 - `docker exec infra-nginx nginx -t`
 
-## 4) 운영자 확인 절차 (배포 직후)
+## 5) 운영자 확인 절차 (배포 직후)
 1. `deploy-instance.sh` 출력에서 version zip / latest 링크 경로를 확인한다.
 2. `instance.zip` 링크가 최신 버전 파일을 가리키는지 확인한다.
 3. `instance.sha256` 링크가 최신 sha 파일을 가리키는지 확인한다.
 4. `sha256sum`과 `cat instance.sha256` 값이 일치하는지 확인한다.
-5. 외부 URL `https://dl.meowti.kr/instance.zip`이 200인지 확인한다.
-6. 문제 시 트러블슈팅 섹션 순서대로 원인을 분류한다.
+5. `curl -I http://dl.meowti.kr/instance.zip`가 301/302/308인지 확인한다.
+6. `curl -I https://dl.meowti.kr/instance.zip`가 200인지 확인한다.

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,12 @@
 - RCON은 인터넷에 publish하지 않습니다(내부 네트워크 또는 로컬 관리 전용).
 - 정적 파일 루트는 nginx에 read-only로 마운트합니다.
 
-## 4) 배포 전 보안 체크
+## 4) TLS/리다이렉트 책임
+- `dl.meowti.kr`의 TLS 종단과 `http -> https` 리다이렉트는 Cloudflare Edge가 담당합니다.
+- Origin nginx는 HTTP 정적 서빙만 담당하며, 리다이렉트 정책은 Cloudflare와 중복 정의하지 않습니다.
+- 검증 기준: HTTP는 `301/302/308`, HTTPS는 `200`, 인증서 경고 없음.
+
+## 5) 배포 전 보안 체크
 - `.env` 파일이 staging 대상에 포함되지 않았는지 확인
 - `git status --short`로 민감 파일 추가 여부 확인
 - `docker compose config`로 예상치 못한 포트 publish 확인


### PR DESCRIPTION
## Plan
- Story #4 범위에서 Cloudflare 담당 HTTPS/리다이렉트 운영 정책을 문서로 고정한다.
- nginx 코드 변경 없이(runbook/security) 검증 절차와 실패 대응을 명확히 한다.
- 현재 실측 결과를 근거로, 이슈 close 전 확인 항목을 분리한다.

## What / Why / How
### What
`docs/runbook.md`, `docs/security.md`에 Cloudflare Edge 책임(HTTPS 종단 + HTTP->HTTPS redirect)과 검증/장애 대응 절차를 추가했습니다.

### Why
이미 설정을 했더라도, 운영자가 언제든 동일한 방법으로 검증할 수 있어야 Story가 유지됩니다. 정책이 문서화되지 않으면 설정 변경/인수인계 시 바로 깨집니다.

### How
- runbook에 Story #4 전용 섹션 추가
  - 검증 명령: `curl -I http://...`, `curl -I https://...`
  - 기대 결과: HTTP `301/302/308`, HTTPS `200`, (선택) HSTS 헤더
  - 실패 시 조치: Cloudflare Redirect Rule/Always Use HTTPS/SSL-TLS 모드 점검
- security 문서에 TLS/redirect 책임 분리 명시

## Acceptance Criteria (Story #4)
- [x] `https://dl.meowti.kr/instance.zip`가 `200 OK`
- [ ] `http://dl.meowti.kr/instance.zip`가 `301/302`로 HTTPS 리다이렉트
- [ ] 브라우저 인증서 경고 없음 (수동 브라우저 확인 필요)
- [x] (선택) HSTS 적용 여부를 문서에서 결정/관리하도록 기준 추가

## Validation (2026-03-10)
```bash
curl -I http://dl.meowti.kr/instance.zip
curl -I https://dl.meowti.kr/instance.zip
```

Observed:
- HTTP: `200 OK` (redirect 미적용)
- HTTPS: `200 OK`

## Risk / Next Action
- 현재 상태는 Story #4 인수 기준 중 HTTP redirect 항목이 미충족입니다.
- Cloudflare에서 `Always Use HTTPS` 또는 Redirect Rule을 재확인 후, 동일 커맨드로 `301/302/308 + Location` 확인 시 이슈 #4 close 가능합니다.

Refs #4
