### PR TITLE
[PR#4] Story: 운영자는 배포 성공 여부를 1분 내 검증할 수 있고, 절차가 runbook으로 문서화된다

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -68,7 +68,42 @@ curl -I https://dl.meowti.kr/instance.zip
 - 인증서 경고가 있으면 Cloudflare SSL/TLS 모드와 인증서 상태를 재확인
 - 원인 확인 후 결과를 본 문서에 날짜와 함께 갱신
 
-## 4) 트러블슈팅
+## 4) 배포 성공 1분 판정 (Story #5)
+
+### 4-1. 절차 (업로드 -> 스크립트 실행 -> 확인)
+```bash
+# 1) 업로드 파일 준비
+ls -l /srv/shared/downloads/instance.zip
+
+# 2) 배포 실행
+cd /srv/infra
+./scripts/deploy-instance.sh /srv/shared/downloads/instance.zip
+
+# 3) 1분 검증
+curl -I http://dl.meowti.kr/instance.zip
+curl -I https://dl.meowti.kr/instance.zip
+curl -I https://dl.meowti.kr/instance.sha256
+ls -l /srv/web/dl.meowti.kr/files/instance.zip
+ls -l /srv/web/dl.meowti.kr/files/instances | tail -n 5
+sha256sum "$(readlink -f /srv/web/dl.meowti.kr/files/instance.zip)"
+cat /srv/web/dl.meowti.kr/files/instance.sha256
+```
+
+### 4-2. 기대 결과
+- HTTP -> `301/302/308` 리다이렉트
+- HTTPS `instance.zip` -> `200 OK`
+- HTTPS `instance.sha256` -> `200 OK`
+- latest 링크(`/instance.zip`)가 최신 버전 파일을 가리킴
+- `instances/`에 신규 버전 파일 존재
+- `sha256sum` 결과와 `instance.sha256` 해시가 동일
+
+### 4-3. 실패 체크포인트(최소)
+- 404: `readlink -f /srv/web/dl.meowti.kr/files/instance.zip` 경로와 파일 존재 확인
+- 403/권한: `namei -l /srv/web/dl.meowti.kr/files` 후 소유권/권한 점검
+- 리로드 누락: `docker exec infra-nginx nginx -t && docker exec infra-nginx nginx -s reload`
+- 무결성 실패: `sha256sum` 결과와 `cat instance.sha256` 비교 후 불일치 시 재배포
+
+## 5) 트러블슈팅
 
 `ERR: input zip not found`:
 - 입력 경로 확인: `ls -l /srv/shared/downloads`
@@ -86,7 +121,7 @@ curl -I https://dl.meowti.kr/instance.zip
 - `docker logs --tail=200 infra-nginx`
 - `docker exec infra-nginx nginx -t`
 
-## 5) 운영자 확인 절차 (배포 직후)
+## 6) 운영자 확인 절차 (배포 직후)
 1. `deploy-instance.sh` 출력에서 version zip / latest 링크 경로를 확인한다.
 2. `instance.zip` 링크가 최신 버전 파일을 가리키는지 확인한다.
 3. `instance.sha256` 링크가 최신 sha 파일을 가리키는지 확인한다.


### PR DESCRIPTION
## Plan
- Story #5 범위로 `docs/runbook.md`만 보강한다.
- 배포 절차를 "업로드 -> 스크립트 실행 -> 1분 검증"으로 고정한다.
- 기대 결과(200/리다이렉트/sha256 일치)와 실패 체크포인트를 명시한다.

## What / Why / How
### What
runbook에 Story #5 전용 섹션을 추가하여 배포 성공 여부를 1분 내 판정하는 절차를 완성했습니다.

### Why
운영자가 배포 직후 정상/비정상을 즉시 판단하지 못하면 장애 복구 시간이 길어집니다. Story #5는 배포 성공의 판단 기준을 문서로 재현 가능하게 만드는 작업입니다.

### How
- `4) 배포 성공 1분 판정 (Story #5)` 섹션 추가
- 명령 순서: 업로드 확인 -> 스크립트 실행 -> HTTP/HTTPS/sha/link 검증
- 기대 결과: HTTP redirect, HTTPS 200, latest 링크/버전 파일/sha 일치
- 실패 체크포인트: 404, 403/권한, nginx 리로드 누락, sha 불일치

## Acceptance Criteria (Story #5)
- [x] `docs/runbook.md`에 배포 절차(업로드 -> 스크립트 실행 -> 확인)가 단계별로 있다.
- [x] `curl` 기반 검증과 기대 결과(200/리다이렉트/sha256 일치)가 있다.
- [x] 실패 시 체크 포인트가 3개 이상 있다(404/403/리로드/무결성).
- [x] 1분 내 확인 항목(latest 링크/버전 파일/sha 일치)이 명시되어 있다.

## Validation (2026-03-10)
```bash
# upload path
ls -l /srv/shared/downloads/instance.zip

# deploy
cd /srv/infra
./scripts/deploy-instance.sh /srv/shared/downloads/instance.zip

# verify
curl -I http://dl.meowti.kr/instance.zip
curl -I https://dl.meowti.kr/instance.zip
curl -I https://dl.meowti.kr/instance.sha256
ls -l /srv/web/dl.meowti.kr/files/instance.zip
ls -l /srv/web/dl.meowti.kr/files/instances | tail -n 5
sha256sum "$(readlink -f /srv/web/dl.meowti.kr/files/instance.zip)"
cat /srv/web/dl.meowti.kr/files/instance.sha256
```

Observed:
- HTTP: `301 Moved Permanently` (`Location: https://dl.meowti.kr/instance.zip`)
- HTTPS `instance.zip`: `200 OK`
- HTTPS `instance.sha256`: `200 OK`
- latest 링크/버전 파일 생성/sha256 일치 확인

## Risk / Note
- `/srv/shared/downloads/instance.zip`가 없으면 스크립트가 실패하므로, 업로드 파이프라인에서 해당 경로 준비를 보장해야 합니다.

Closes #5
