### PR TITLE
ops: check-deploy 자동 검증 스크립트 추가

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -79,7 +79,12 @@ ls -l /srv/shared/downloads/instance.zip
 cd /srv/infra
 ./scripts/deploy-instance.sh /srv/shared/downloads/instance.zip
 
-# 3) 1분 검증
+# 3) 1분 자동 검증 (권장)
+./scripts/check-deploy.sh
+```
+
+### 4-2. 수동 보조 검증 (스크립트 실패 시)
+```bash
 curl -I http://dl.meowti.kr/instance.zip
 curl -I https://dl.meowti.kr/instance.zip
 curl -I https://dl.meowti.kr/instance.sha256
@@ -89,7 +94,8 @@ sha256sum "$(readlink -f /srv/web/dl.meowti.kr/files/instance.zip)"
 cat /srv/web/dl.meowti.kr/files/instance.sha256
 ```
 
-### 4-2. 기대 결과
+### 4-3. 기대 결과
+- `./scripts/check-deploy.sh` 종료 코드가 `0`
 - HTTP -> `301/302/308` 리다이렉트
 - HTTPS `instance.zip` -> `200 OK`
 - HTTPS `instance.sha256` -> `200 OK`
@@ -97,7 +103,7 @@ cat /srv/web/dl.meowti.kr/files/instance.sha256
 - `instances/`에 신규 버전 파일 존재
 - `sha256sum` 결과와 `instance.sha256` 해시가 동일
 
-### 4-3. 실패 체크포인트(최소)
+### 4-4. 실패 체크포인트(최소)
 - 404: `readlink -f /srv/web/dl.meowti.kr/files/instance.zip` 경로와 파일 존재 확인
 - 403/권한: `namei -l /srv/web/dl.meowti.kr/files` 후 소유권/권한 점검
 - 리로드 누락: `docker exec infra-nginx nginx -t && docker exec infra-nginx nginx -s reload`
@@ -125,6 +131,6 @@ cat /srv/web/dl.meowti.kr/files/instance.sha256
 1. `deploy-instance.sh` 출력에서 version zip / latest 링크 경로를 확인한다.
 2. `instance.zip` 링크가 최신 버전 파일을 가리키는지 확인한다.
 3. `instance.sha256` 링크가 최신 sha 파일을 가리키는지 확인한다.
-4. `sha256sum`과 `cat instance.sha256` 값이 일치하는지 확인한다.
-5. `curl -I http://dl.meowti.kr/instance.zip`가 301/302/308인지 확인한다.
-6. `curl -I https://dl.meowti.kr/instance.zip`가 200인지 확인한다.
+4. `./scripts/check-deploy.sh`를 실행해 자동 검증 결과를 확인한다.
+5. 자동 검증 실패 시 수동 보조 검증으로 항목별 원인을 분리한다.
+6. `curl -I https://dl.meowti.kr/instance.zip`가 200인지 최종 확인한다.

--- a/scripts/check-deploy.sh
+++ b/scripts/check-deploy.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-dl.meowti.kr}"
+WEB_ROOT="${WEB_ROOT:-/srv/web/dl.meowti.kr/files}"
+INSTANCE_PATH="${INSTANCE_PATH:-/instance.zip}"
+SHA_PATH="${SHA_PATH:-/instance.sha256}"
+
+fail_count=0
+
+pass() {
+  echo "[PASS] $*"
+}
+
+fail() {
+  echo "[FAIL] $*" >&2
+  fail_count=$((fail_count + 1))
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERR: required command not found: $1" >&2
+    exit 2
+  }
+}
+
+first_status_code() {
+  awk 'toupper($1) ~ /^HTTP\// {print $2; exit}'
+}
+
+first_location() {
+  awk 'tolower($1) == "location:" {print $2; exit}' | tr -d '\r'
+}
+
+require_cmd curl
+require_cmd sha256sum
+require_cmd readlink
+require_cmd awk
+
+latest_zip="$WEB_ROOT/instance.zip"
+latest_sha="$WEB_ROOT/instance.sha256"
+instances_dir="$WEB_ROOT/instances"
+
+if [[ -e "$latest_zip" ]]; then
+  pass "latest zip exists: $latest_zip"
+else
+  fail "latest zip missing: $latest_zip"
+fi
+
+if [[ -e "$latest_sha" ]]; then
+  pass "latest sha exists: $latest_sha"
+else
+  fail "latest sha missing: $latest_sha"
+fi
+
+if compgen -G "$instances_dir/instance-*.zip" >/dev/null; then
+  pass "versioned zip exists in: $instances_dir"
+else
+  fail "no versioned zip found in: $instances_dir"
+fi
+
+http_headers="$(curl -sSI --max-time 20 "http://$DOMAIN$INSTANCE_PATH" || true)"
+http_status="$(printf '%s\n' "$http_headers" | first_status_code)"
+http_location="$(printf '%s\n' "$http_headers" | first_location)"
+
+if [[ "$http_status" =~ ^(301|302|308)$ ]]; then
+  pass "http redirect status: $http_status"
+else
+  fail "http redirect status expected 301/302/308, got: ${http_status:-none}"
+fi
+
+expected_https_location="https://$DOMAIN$INSTANCE_PATH"
+if [[ "$http_location" == "$expected_https_location" ]]; then
+  pass "http location header: $http_location"
+else
+  fail "http location expected $expected_https_location, got: ${http_location:-none}"
+fi
+
+https_zip_headers="$(curl -sSI --max-time 20 "https://$DOMAIN$INSTANCE_PATH" || true)"
+https_zip_status="$(printf '%s\n' "$https_zip_headers" | first_status_code)"
+if [[ "$https_zip_status" == "200" ]]; then
+  pass "https instance status: 200"
+else
+  fail "https instance status expected 200, got: ${https_zip_status:-none}"
+fi
+
+https_sha_headers="$(curl -sSI --max-time 20 "https://$DOMAIN$SHA_PATH" || true)"
+https_sha_status="$(printf '%s\n' "$https_sha_headers" | first_status_code)"
+if [[ "$https_sha_status" == "200" ]]; then
+  pass "https sha status: 200"
+else
+  fail "https sha status expected 200, got: ${https_sha_status:-none}"
+fi
+
+latest_zip_target="$(readlink -f "$latest_zip" || true)"
+if [[ -n "$latest_zip_target" && -f "$latest_zip_target" ]]; then
+  pass "latest zip target exists: $latest_zip_target"
+else
+  fail "latest zip target is invalid"
+fi
+
+sha_expected="$(awk 'NR==1 {print $1}' "$latest_sha" | tr -d '\r' || true)"
+sha_actual="$(sha256sum "$latest_zip_target" | awk '{print $1}' || true)"
+
+if [[ -n "$sha_expected" && "$sha_expected" == "$sha_actual" ]]; then
+  pass "sha256 matches latest zip"
+else
+  fail "sha256 mismatch: expected=${sha_expected:-none} actual=${sha_actual:-none}"
+fi
+
+if [[ "$fail_count" -gt 0 ]]; then
+  echo "RESULT: FAIL ($fail_count checks failed)" >&2
+  exit 1
+fi
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What
- `scripts/check-deploy.sh` 추가
- runbook Story #5를 "스크립트 우선 + curl 보조" 흐름으로 전환

## Why
수동 `curl` 절차는 누락 가능성이 있어 운영 실수 감소에 한계가 있습니다. 자동화 스크립트로 일관된 판정(`exit code`)을 제공하고, 실패 시에만 수동 커맨드로 원인 분리를 하도록 바꿨습니다.

## How
- check script가 아래를 자동 점검
  - latest/sha 파일 존재
  - versioned 파일 존재
  - HTTP redirect status + Location
  - HTTPS instance/sha status
  - latest target 유효성
  - sha256 일치
- runbook에 자동 검증 명령을 기본 경로로 배치하고 수동 검증은 보조로 이동

## Validation
```bash
cd /srv/infra
bash -n scripts/check-deploy.sh
./scripts/check-deploy.sh
```

Observed:
- 모든 체크 `PASS`
- `RESULT: PASS`
