### PR TITLE
[PR] Story #17: dashboard 업스트림 프록시 기준 확정

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -187,3 +187,30 @@ docker logs --tail=100 infra-nginx
 - `502` 발생 시 API 업스트림(`api:8080`) 컨테이너 기동 및 네트워크 연결 확인
 - `api` 이름 해석 실패 시 컨테이너가 `frontdoor-net`에 조인되었는지 확인 후 nginx 재기동
 - 경로 미매칭 시 `server_name api.meowti.kr` 및 `proxy_pass` 설정 확인
+
+## 8) dashboard 프록시 점검 (Story #17)
+
+사전 조건:
+- nginx 설정 파일 존재: `/srv/infra/nginx/conf.d/dashboard.meowti.kr.conf`
+- dashboard(Next.js) 컨테이너가 `frontdoor-net`에서 `dashboard:3000`으로 동작한다.
+
+자동 검증(권장):
+```bash
+cd /srv/infra
+./scripts/check-dashboard-proxy.sh
+```
+
+수동 보조 검증:
+```bash
+curl -I -H 'Host: dashboard.meowti.kr' http://127.0.0.1/
+docker logs --tail=100 infra-nginx
+```
+
+기대 결과:
+- `/` -> `200 OK`
+- nginx 로그에서 upstream 연결 오류가 없어야 함
+
+실패 시 조치:
+- `502` 발생 시 dashboard 업스트림(`dashboard:3000`) 컨테이너 기동 및 네트워크 연결 확인
+- `dashboard` 이름 해석 실패 시 컨테이너가 `frontdoor-net`에 조인되었는지 확인 후 nginx 재기동
+- 경로 미매칭 시 `server_name dashboard.meowti.kr` 및 `proxy_pass` 설정 확인

--- a/nginx/conf.d/dashboard.meowti.kr.conf
+++ b/nginx/conf.d/dashboard.meowti.kr.conf
@@ -1,0 +1,18 @@
+server {
+  listen 80;
+  server_name dashboard.meowti.kr;
+
+  resolver 127.0.0.11 ipv6=off valid=10s;
+  set $dashboard_upstream dashboard:3000;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_connect_timeout 3s;
+    proxy_send_timeout 30s;
+    proxy_read_timeout 30s;
+    proxy_pass http://$dashboard_upstream;
+  }
+}

--- a/scripts/check-dashboard-proxy.sh
+++ b/scripts/check-dashboard-proxy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="${COMPOSE_FILE:-compose/nginx/docker-compose.yml}"
+CONF_FILE="${CONF_FILE:-nginx/conf.d/dashboard.meowti.kr.conf}"
+CONTAINER_NAME="${CONTAINER_NAME:-infra-nginx}"
+DOMAIN="${DOMAIN:-dashboard.meowti.kr}"
+NETWORK_NAME="${NETWORK_NAME:-frontdoor-net}"
+
+pass() {
+  echo "[PASS] $*"
+}
+
+fail() {
+  echo "[FAIL] $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+require_cmd docker
+require_cmd curl
+
+[[ -f "$COMPOSE_FILE" ]] || fail "compose file not found: $COMPOSE_FILE"
+[[ -f "$CONF_FILE" ]] || fail "nginx conf file not found: $CONF_FILE"
+
+grep -q "server_name $DOMAIN;" "$CONF_FILE" || fail "server_name '$DOMAIN' not found in $CONF_FILE"
+pass "nginx server_name is $DOMAIN"
+
+grep -q 'set \$dashboard_upstream dashboard:3000;' "$CONF_FILE" || fail "dashboard upstream variable not configured as dashboard:3000"
+pass "dashboard upstream variable is dashboard:3000"
+
+grep -q 'proxy_pass http://\$dashboard_upstream;' "$CONF_FILE" || fail "proxy_pass is not using dashboard_upstream variable"
+pass "proxy_pass uses dashboard_upstream variable"
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+  fail "container not running: $CONTAINER_NAME"
+fi
+pass "container is running: $CONTAINER_NAME"
+
+if ! docker inspect -f '{{json .NetworkSettings.Networks}}' "$CONTAINER_NAME" | grep -q "$NETWORK_NAME"; then
+  fail "container network missing: $NETWORK_NAME"
+fi
+pass "container network includes $NETWORK_NAME"
+
+local_root_code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Host: $DOMAIN" "http://127.0.0.1/")"
+[[ "$local_root_code" == "200" ]] || fail "local / status is '$local_root_code' (expected: 200)"
+pass "local / status is 200"
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What
- `dashboard.meowti.kr` 전용 nginx server block을 추가했습니다.
- `scripts/check-dashboard-proxy.sh`를 추가해 Story #17 수용 기준을 자동 점검하도록 했습니다.
- runbook에 Story #17 운영 점검 절차(자동/수동/실패 대응)를 추가했습니다.

## Why
- Story #17의 목표는 `dashboard.<domain>` 요청을 Next.js 업스트림으로 전달하고, 장애 시 운영자가 로그로 원인 분리할 수 있게 만드는 것입니다.

## How
- nginx conf: `nginx/conf.d/dashboard.meowti.kr.conf`
  - `server_name dashboard.meowti.kr`
  - `set $dashboard_upstream dashboard:3000`
  - `proxy_pass http://$dashboard_upstream`
  - `resolver 127.0.0.11` (Docker DNS)
- 검증 스크립트: `scripts/check-dashboard-proxy.sh`
  - server_name/upstream 설정/네트워크 연결/로컬 `/` 200 점검
- runbook: Story #17 점검 섹션 추가

## Acceptance Criteria
- [x] `dashboard.<domain>` 요청이 dashboard 업스트림으로 전달된다.
- [x] 기본 경로(`/`) 응답 확인이 가능하다.
- [x] 장애 시 nginx 로그로 원인 분리가 가능하다.

## Verification
```bash
cd /srv/infra

docker compose -f compose/nginx/docker-compose.yml up -d

# PR 검증용 임시 업스트림(mock)
docker rm -f story17-mock-dashboard >/dev/null 2>&1 || true
docker run -d --rm --name story17-mock-dashboard \
  --network frontdoor-net \
  --network-alias dashboard \
  hashicorp/http-echo:1.0.0 -listen=:3000 -text=dashboard-ok

bash -n scripts/check-dashboard-proxy.sh
./scripts/check-dashboard-proxy.sh
curl -I -H 'Host: dashboard.meowti.kr' http://127.0.0.1/

docker rm -f story17-mock-dashboard
```

실행 결과 요약:
- `./scripts/check-dashboard-proxy.sh` -> `RESULT: PASS`
- `curl -I -H 'Host: dashboard.meowti.kr' http://127.0.0.1/` -> `HTTP/1.1 200 OK`

## Risk / Follow-up
- 현재 `dashboard.meowti.kr` public DNS는 아직 미구성(`Could not resolve host`)입니다. 외부 접근 검증은 DNS 연결 후 수행 필요.
